### PR TITLE
Add rigid self-belief demo

### DIFF
--- a/demo/demo_self_beliefs.py
+++ b/demo/demo_self_beliefs.py
@@ -1,0 +1,23 @@
+from memo import memo
+import jax.numpy as np
+from enum import IntEnum
+
+class SelfBelief(IntEnum):
+    WORTHLESS = 0
+    UNLOVABLE = 1
+    INCOMPETENT = 2
+
+B = np.arange(len(SelfBelief))
+
+# Different confidences for each negative belief
+belief_probs = np.array([0.6, 0.25, 0.15])
+
+@memo
+def self_beliefs[b: B]():
+    """Return the probability that "self" holds negative belief b."""
+    self: chooses(belief in B, wpp=belief_probs[belief])
+    self: thinks[ self: knows(belief) ]
+    return self[Pr[self.belief == b]]
+
+if __name__ == "__main__":
+    print(self_beliefs())

--- a/demo/demo_self_beliefs_rigidity.py
+++ b/demo/demo_self_beliefs_rigidity.py
@@ -1,0 +1,33 @@
+from memo import memo
+import jax.numpy as np
+from enum import IntEnum
+
+class SelfBelief(IntEnum):
+    WORTHLESS = 0
+    UNLOVABLE = 1
+    INCOMPETENT = 2
+
+class Rigidity(IntEnum):
+    FLEXIBLE = 0
+    RIGID = 1
+    VERY_RIGID = 2
+
+B = np.arange(len(SelfBelief))
+R = np.arange(len(Rigidity))
+
+belief_probs = np.array([0.6, 0.25, 0.15])
+rigidity_probs = np.array([0.5, 0.35, 0.15])
+
+@memo
+def self_beliefs_rigid[b: B, r: R]():
+    """Joint belief and rigidity distribution for the "self" agent."""
+    # Sample rigidity level first (hierarchical)
+    self: chooses(rigidity in R, wpp=rigidity_probs[rigidity])
+    weighted = belief_probs ** (1 + self.rigidity)
+    weighted = weighted / weighted.sum()
+    self: chooses(belief in B, wpp=weighted[belief])
+    self: thinks[ self: knows(belief) ]
+    return self[Pr[(self.belief == b) & (self.rigidity == r)]]
+
+if __name__ == "__main__":
+    print(self_beliefs_rigid())


### PR DESCRIPTION
## Summary
- extend the self belief demo with a new variant that models belief rigidity

## Testing
- `python3.12 demo/demo_self_beliefs.py` *(fails: ModuleNotFoundError: No module named 'jax')*
- `python3.12 demo/demo_self_beliefs_rigidity.py` *(fails: ModuleNotFoundError: No module named 'jax')*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683dc3037f8883229227b1256c57bef1