### PR TITLE
Add hierarchical self belief demo

### DIFF
--- a/demo/demo_self_beliefs.py
+++ b/demo/demo_self_beliefs.py
@@ -1,0 +1,23 @@
+from memo import memo
+import jax.numpy as np
+from enum import IntEnum
+
+class SelfBelief(IntEnum):
+    WORTHLESS = 0
+    UNLOVABLE = 1
+    INCOMPETENT = 2
+
+B = np.arange(len(SelfBelief))
+
+# Different confidences for each negative belief
+belief_probs = np.array([0.6, 0.25, 0.15])
+
+@memo
+def self_beliefs[b: B]():
+    """Return the probability that "self" holds negative belief ``b``."""
+    self: chooses(belief in B, wpp=belief_probs)
+    self: thinks[ self: knows(belief) ]
+    return self[Pr[self.belief == b]]
+
+if __name__ == "__main__":
+    print(self_beliefs())

--- a/demo/demo_self_beliefs_rigidity.py
+++ b/demo/demo_self_beliefs_rigidity.py
@@ -1,0 +1,38 @@
+from memo import memo
+import jax.numpy as np
+from enum import IntEnum
+
+class SelfBelief(IntEnum):
+    WORTHLESS = 0
+    UNLOVABLE = 1
+    INCOMPETENT = 2
+
+B = np.arange(len(SelfBelief))
+
+# Base confidences for each negative belief
+belief_probs = np.array([0.6, 0.25, 0.15])
+
+class Rigidity(IntEnum):
+    LOW = 0
+    MEDIUM = 1
+    HIGH = 2
+
+# Numerical rigidity levels (higher = beliefs weighted more sharply)
+rigidity_levels = np.array([0.5, 1.0, 2.0])
+R = np.arange(len(Rigidity))
+
+# Prior over rigidity choices (uniform here)
+rigidity_prior = np.array([1/3, 1/3, 1/3])
+
+@memo
+def self_beliefs_rigidity[r: R, b: B]():
+    """Probability "self" holds belief ``b`` given rigidity ``r``."""
+    meta_self: chooses(rig in R, wpp=rigidity_prior[rig])
+    meta_self: thinks[
+        self: knows(rig),
+        self: chooses(belief in B, wpp=belief_probs ** rigidity_levels[rig])
+    ]
+    return meta_self[Pr[self.belief == b]]
+
+if __name__ == "__main__":
+    print(self_beliefs_rigidity())


### PR DESCRIPTION
## Summary
- fix probability assignment in self-beliefs demo
- add a new demo with a rigidity hierarchy for self-beliefs

## Testing
- `python3.12 demo/demo_self_beliefs.py` *(fails: ModuleNotFoundError: No module named 'jax')*
- `python3.12 demo/demo_self_beliefs_rigidity.py` *(fails: ModuleNotFoundError: No module named 'jax')*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683dc3037f8883229227b1256c57bef1